### PR TITLE
A workaround for older versions of unshare

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,6 +8,10 @@ function execute () {
   child_process.execSync(shellEscape(Array.from(arguments)), { stdio: [0, 1, 2] });
 }
 
+function executePiped (cmd1, cmd2) {
+  child_process.execSync(shellEscape(cmd1) + ' | ' + shellEscape(cmd2), { stdio: [0, 1, 2] });
+}
+
 module.exports = class Sandbox {
   constructor (binds) {
     this.tmpDir = tmp.dirSync();
@@ -98,7 +102,7 @@ module.exports = class Sandbox {
     if (options.network) {
       execute('sh', '-c', cmd);
     } else {
-      execute('unshare', '-n', 'sh', '-c', cmd);
+      executePiped(['echo', cmd], ['unshare', '-n', 'sh']);
     }
 
     function parseResult (result) {


### PR DESCRIPTION
![Old versions of unshare](http://www.unix.com/man-page/linux/1/unshare/) recognizes the `-c` as its own argument, rather than passes it to `sh` - -||

This would be a simple workaround. Perhaps can be made more elegant.